### PR TITLE
Fix nested/implicit attention demos: pass return_kv_cache=True

### DIFF
--- a/titans_pytorch/implicit_mlp_attention.py
+++ b/titans_pytorch/implicit_mlp_attention.py
@@ -155,7 +155,7 @@ if __name__ == '__main__':
 
     tokens = torch.randn(1, 1024, 512)
 
-    out, cache = implicit_mlp_attn(tokens)
-    out, cache = implicit_mlp_attn(tokens, cache = cache)
+    out, cache = implicit_mlp_attn(tokens, return_kv_cache = True)
+    out, cache = implicit_mlp_attn(tokens, cache = cache, return_kv_cache = True)
 
     assert out.shape == tokens.shape

--- a/titans_pytorch/nested_attention.py
+++ b/titans_pytorch/nested_attention.py
@@ -116,8 +116,8 @@ if __name__ == '__main__':
 
     tokens = torch.randn(1, 1024, 512)
 
-    out1, cache = nested_attn(tokens)
-    out2, cache = nested_attn(tokens[:, -1:], cache = cache)
+    out1, cache = nested_attn(tokens, return_kv_cache = True)
+    out2, cache = nested_attn(tokens[:, -1:], cache = cache, return_kv_cache = True)
 
     assert out1.shape == tokens.shape
     assert out2.shape == (1, 1, 512)


### PR DESCRIPTION
The `__main__` demos in `nested_attention.py` and `implicit_mlp_attention.py` both do:

```python
out, cache = module(tokens)
```

but `forward` only returns the cache when `return_kv_cache = True` is passed (otherwise it returns just the output tensor). So running either file as-is fails immediately:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

This adds `return_kv_cache = True` to the demo calls (including the cached follow-up calls). Both files now run and pass their asserts.
